### PR TITLE
Use zero as default sub ID

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -11,7 +11,7 @@
 class Pronamic_WP_Pay_Gateways_IDealAdvancedV3_Config extends Pronamic_WP_Pay_GatewayConfig {
 	public $merchant_id;
 
-	public $sub_id;
+	public $sub_id = 0;
 
 	public $private_key_password;
 


### PR DESCRIPTION
If no Sub ID is specified in the iDEAL configuration, use the default Sub ID of "0".
