### PR TITLE
The `Error` class extends `\Exception` class for simplicity and to prevent string concat

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -173,9 +173,7 @@ class Client {
 			case AcquirerErrorResMessage::NAME:
 				$message = AcquirerErrorResMessage::parse( $document );
 
-				throw new \Exception(
-					sprintf( '%s. %s', $message->error->get_message(), $message->error->get_detail() )
-				);
+				throw $message->error;
 			case DirectoryResponseMessage::NAME:
 				return DirectoryResponseMessage::parse( $document );
 			case TransactionResponseMessage::NAME:

--- a/src/Error.php
+++ b/src/Error.php
@@ -19,27 +19,20 @@ namespace Pronamic\WordPress\Pay\Gateways\IDealAdvancedV3;
  * @author  Remco Tolsma
  * @version 2.0.0
  */
-class Error {
+class Error extends \Exception {
 	/**
-	 * Code
+	 * Error code
 	 *
 	 * @var string
 	 */
-	private $code;
+	private $error_code;
 
 	/**
-	 * Message
+	 * Error detail
 	 *
 	 * @var string
 	 */
-	private $message;
-
-	/**
-	 * Detail
-	 *
-	 * @var string
-	 */
-	private $detail;
+	private $error_detail;
 
 	/**
 	 * Suggested action
@@ -56,9 +49,21 @@ class Error {
 	private $consumer_message;
 
 	/**
-	 * Construct and initialize an error.
+	 * Construct error.
+	 * 
+	 * @param string $code             Code.
+	 * @param string $message          Message.
+	 * @param string $detail           Detail.
+	 * @param string $suggested_action Suggested action.
+	 * @param string $consumer_message Consumer message.
 	 */
-	public function __construct() {
+	public function __construct( $code, $message, $detail, $suggested_action, $consumer_message ) {
+		parent::__construct( $message );
+
+		$this->error_code       = $code;
+		$this->error_detail     = $detail;
+		$this->suggested_action = $suggested_action;
+		$this->consumer_message = $consumer_message;
 	}
 
 	/**
@@ -67,7 +72,7 @@ class Error {
 	 * @return string
 	 */
 	public function get_code() {
-		return $this->code;
+		return $this->error_code;
 	}
 
 	/**
@@ -77,7 +82,7 @@ class Error {
 	 * @return void
 	 */
 	public function set_code( $code ) {
-		$this->code = $code;
+		$this->error_code = $code;
 	}
 
 	/**
@@ -105,7 +110,7 @@ class Error {
 	 * @return string
 	 */
 	public function get_detail() {
-		return $this->detail;
+		return $this->error_detail;
 	}
 
 	/**
@@ -115,7 +120,7 @@ class Error {
 	 * @return void
 	 */
 	public function set_detail( $detail ) {
-		$this->detail = $detail;
+		$this->error_detail = $detail;
 	}
 
 	/**

--- a/src/Error.php
+++ b/src/Error.php
@@ -76,32 +76,12 @@ class Error extends \Exception {
 	}
 
 	/**
-	 * Set error code.
-	 *
-	 * @param string $code Error code.
-	 * @return void
-	 */
-	public function set_code( $code ) {
-		$this->error_code = $code;
-	}
-
-	/**
 	 * Get error message.
 	 *
 	 * @return string
 	 */
 	public function get_message() {
 		return $this->message;
-	}
-
-	/**
-	 * Set error message.
-	 *
-	 * @param string $message Error message.
-	 * @return void
-	 */
-	public function set_message( $message ) {
-		$this->message = $message;
 	}
 
 	/**
@@ -114,16 +94,6 @@ class Error extends \Exception {
 	}
 
 	/**
-	 * Set error detail.
-	 *
-	 * @param string $detail Detail.
-	 * @return void
-	 */
-	public function set_detail( $detail ) {
-		$this->error_detail = $detail;
-	}
-
-	/**
 	 * Get suggested action.
 	 *
 	 * @return string
@@ -133,32 +103,12 @@ class Error extends \Exception {
 	}
 
 	/**
-	 * Set suggested action.
-	 *
-	 * @param string $suggested_action Suggested action.
-	 * @return void
-	 */
-	public function set_suggested_action( $suggested_action ) {
-		$this->suggested_action = $suggested_action;
-	}
-
-	/**
 	 * Get consumer message.
 	 *
 	 * @return string
 	 */
 	public function get_consumer_message() {
 		return $this->consumer_message;
-	}
-
-	/**
-	 * Set consumer message.
-	 *
-	 * @param string $consumer_message Consumer message.
-	 * @return void
-	 */
-	public function set_consumer_message( $consumer_message ) {
-		$this->consumer_message = $consumer_message;
 	}
 
 	/**

--- a/src/Error.php
+++ b/src/Error.php
@@ -110,13 +110,4 @@ class Error extends \Exception {
 	public function get_consumer_message() {
 		return $this->consumer_message;
 	}
-
-	/**
-	 * Create a string representation of this object.
-	 *
-	 * @return string
-	 */
-	public function __toString() {
-		return $this->code . ' ' . $this->message;
-	}
 }

--- a/src/XML/ErrorParser.php
+++ b/src/XML/ErrorParser.php
@@ -34,14 +34,12 @@ class ErrorParser {
 			return null;
 		}
 
-		$error = new Error();
-
-		$error->set_code( (string) $xml->errorCode );
-		$error->set_message( (string) $xml->errorMessage );
-		$error->set_detail( (string) $xml->errorDetail );
-		$error->set_suggested_action( (string) $xml->suggestedAction );
-		$error->set_consumer_message( (string) $xml->consumerMessage );
-
-		return $error;
+		return new Error(
+			(string) $xml->errorCode,
+			(string) $xml->errorMessage,
+			(string) $xml->errorDetail,
+			(string) $xml->suggestedAction,
+			(string) $xml->consumerMessage
+		);
 	}
 }

--- a/tests/src/ErrorTest.php
+++ b/tests/src/ErrorTest.php
@@ -25,15 +25,19 @@ class ErrorTest extends TestCase {
 	/**
 	 * Test error to string.
 	 */
-	public function testToStringError() {
-		$error = new Error();
-		$error->set_code( '1' );
-		$error->set_message( 'Error' );
+	public function test_error() {
+		$error = new Error(
+			'AP9901',
+			'merchantID not found in XML data. Please validate your XML.',
+			'merchantID not found in XML data. Please validate your XML.',
+			'Please try again later or pay using another payment method.',
+			'Betalen met iDEAL is nu niet mogelijk. Probeer het later nogmaals of betaal op een andere manier.'
+		);
 
-		$string = (string) $error;
-
-		$expected = '1 Error';
-
-		$this->assertEquals( $expected, $string );
+		$this->assertEquals( 'AP9901', $error->get_code() );
+		$this->assertEquals( 'merchantID not found in XML data. Please validate your XML.', $error->get_message() );
+		$this->assertEquals( 'merchantID not found in XML data. Please validate your XML.', $error->get_detail() );
+		$this->assertEquals( 'Please try again later or pay using another payment method.', $error->get_suggested_action() );
+		$this->assertEquals( 'Betalen met iDEAL is nu niet mogelijk. Probeer het later nogmaals of betaal op een andere manier.', $error->get_consumer_message() );
 	}
 }

--- a/tests/src/XML/ErrorParserTest.php
+++ b/tests/src/XML/ErrorParserTest.php
@@ -40,7 +40,7 @@ class ErrorParserTest extends TestCase {
 		$this->assertSame( 'SO1100', $error->get_code() );
 		$this->assertSame( 'Issuer not available', $error->get_message() );
 		$this->assertSame( 'System generating error: Rabobank', $error->get_detail() );
-		$this->assertSame( null, $error->get_suggested_action() );
+		$this->assertSame( '', $error->get_suggested_action() );
 		$this->assertSame( 'De geselecteerde iDEAL bank is momenteel niet beschikbaar i.v.m. onderhoud tot naar verwachting 31-12-2010 03:30. Probeer het later nogmaals of betaal op een andere manier.', $error->get_consumer_message() );
 	}
 }


### PR DESCRIPTION
- https://github.com/pronamic/wp-pronamic-pay-ideal-advanced-v3/issues/9

<img width="653" alt="Scherm­afbeelding 2023-01-12 om 14 43 18" src="https://user-images.githubusercontent.com/869674/212082811-3c13b57b-32f2-4c06-9fc7-d5e02407518c.png">
